### PR TITLE
fix: wordpressのDBユーザー追加

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -26,6 +26,8 @@ services:
             - ./public:/var/www/html
         environment:
             WORDPRESS_DB_HOST: database:3306
+            WORDPRESS_DB_NAME: wordpress
+            WORDPRESS_DB_USER: wordpress
             WORDPRESS_DB_PASSWORD: wordpress
     wordmove:
         tty: true


### PR DESCRIPTION
- `WORDPRESS_DB_USER` はデフォルトがあると便利なので追記できたらと思いました。
- `WORDPRESS_DB_NAME` の方は WordPress 側のデフォルトで値 `wordpress` が設定されるのでなくてもかまわないかもしれません。